### PR TITLE
feat: add subfolders option for independent color rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -524,9 +524,9 @@
 			}
 		},
 		"node_modules/@eslint/config-array/node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -600,9 +600,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -662,15 +662,29 @@
 			}
 		},
 		"node_modules/@eslint/plugin-kit": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.1.tgz",
-			"integrity": "sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==",
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
+			"integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"@eslint/core": "^0.14.0",
+				"@eslint/core": "^0.15.2",
 				"levn": "^0.4.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+			"integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1458,9 +1472,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1813,9 +1827,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,

--- a/styles.scss
+++ b/styles.scss
@@ -143,6 +143,30 @@ Obsidian Rainbow Colored Sidebar
 		);
 	}
 
+	.rcs-item-#{$i}.sub-rcs .nav-folder-title {
+		color: color-mix(in srgb, var(--rcs-color-#{$i}) var(--rcs-base-color-modifier), var(--rcs-contrast-color)) !important;
+		--nav-item-color-hover: color-mix(in srgb, var(--rcs-color-#{$i}) var(--rcs-hover-color-modifier), var(--rcs-default-text-color)) !important;
+		--nav-item-background-hover: color-mix(in srgb, var(--rcs-color-#{$i}) var(--rcs-bg-contrast-modifier), transparent) !important;
+		--background-modifier-border-focus: color-mix(in srgb, var(--rcs-color-#{$i}) var(--rcs-border-focus-modifier), transparent) !important;
+		--nav-collapse-icon-color: color-mix(in srgb, var(--rcs-color-#{$i}) var(--rcs-icon-color-modifier), transparent) !important;
+	}
+
+	.rcs-item-#{$i}.sub-rcs .tree-item-children {
+		--nav-indentation-guide-color: color-mix(in srgb, var(--rcs-color-#{$i}) var(--rcs-indent-color-modifier), transparent) !important;
+	}
+
+	.rcs-item-#{$i}.sub-rcs .tree-item-children .nav-file-title {
+		color: color-mix(in srgb, var(--rcs-color-#{$i}) var(--rcs-base-color-modifier), var(--rcs-default-text-color)) !important;
+		--nav-item-color-hover: color-mix(in srgb, var(--rcs-color-#{$i}) var(--rcs-hover-color-modifier), var(--rcs-default-text-color)) !important;
+		--nav-item-background-hover: color-mix(in srgb, var(--rcs-color-#{$i}) var(--rcs-bg-contrast-modifier), transparent) !important;
+		--background-modifier-border-focus: color-mix(in srgb, var(--rcs-color-#{$i}) var(--rcs-border-focus-modifier), transparent) !important;
+		--nav-item-background-active: color-mix(in srgb, var(--rcs-color-#{$i}) var(--rcs-active-contrast-modifier), transparent) !important;
+	}
+
+	.rcs-item-#{$i}.sub-rcs .tree-item-children .nav-file-title.is-active {
+		color: color-mix(in srgb, var(--rcs-color-#{$i}) var(--rcs-active-contrast-modifier), var(--rcs-default-text-color)) !important;
+	}
+
 	/* End of Loop */
 }
 


### PR DESCRIPTION
1. Implemented a new section into the setting page, to directly select specific folders for custom styling. (with folder search and auto-complete).
2. Implemented a function to read the folders from the setting, and then assign css classes to them.
3. Added corresponding css for rendering.

The effects are as follows:
<img width="546" height="758" alt="image" src="https://github.com/user-attachments/assets/f5f7db78-6573-4d16-b4e1-5aba94094efc" />

<img width="241" height="693" alt="image" src="https://github.com/user-attachments/assets/c666ad1b-866f-4711-9ebf-f01b5b63c0a5" />
