### PR TITLE
filter dot folders and sort properly

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -73,8 +73,15 @@ export default class RainbowColoredSidebar extends Plugin {
 		const colorCount = schemes[this.settings.scheme].colors.length;
 
 		// Get all folders from the root path, child folders are not needed here
+		// Then filter out invisible folders, and sort alphanumerically
 		const folders = (await this.app.vault.adapter.list('/')).folders
-			.filter((folder) => folder !== this.app.vault.configDir);
+			.filter((folder) =>
+				!folder.startsWith('.')
+			)
+			.sort((a, b) => a.localeCompare(b, undefined, {
+				numeric: true,
+				caseFirst: 'lower'
+			}));
 		if (folders) {
 			for (let i = 0; i < folders.length; i++) {
 				// Add rcs-item-x classes to all folders based on data-path with the active scheme repeating indefinitely


### PR DESCRIPTION
Fixes #11

Filter away `.folder/` as well, such as the `.git` folder that many (I) have.

I added a sorting step after filtering away those `.folder` because the function doesn't always return the folder list sorted, such as on iOS.