### PR TITLE
fix: folder colors not applied on recent Obsidian (file explorer DOM change)

### DIFF
--- a/styles.scss
+++ b/styles.scss
@@ -71,7 +71,7 @@ Obsidian Rainbow Colored Sidebar
 /* Loop over all available colors */
 @for $i from 1 through 16 {
 
-	.nav-files-container > div > .nav-folder.rcs-item-#{$i} .nav-folder-title {
+	.nav-files-container .nav-folder.rcs-item-#{$i} .nav-folder-title {
 		color: color-mix(
 				in srgb,
 				var(--rcs-color-#{$i}) var(--rcs-base-color-modifier),
@@ -99,7 +99,7 @@ Obsidian Rainbow Colored Sidebar
 		);
 	}
 
-	.nav-files-container > div > .nav-folder.rcs-item-#{$i} .tree-item-children {
+	.nav-files-container .nav-folder.rcs-item-#{$i} .tree-item-children {
 		--nav-indentation-guide-color: color-mix(
 				in srgb,
 				var(--rcs-color-#{$i}) var(--rcs-indent-color-modifier),
@@ -107,7 +107,7 @@ Obsidian Rainbow Colored Sidebar
 		);
 	}
 
-	.nav-files-container > div > .nav-folder.rcs-item-#{$i} .tree-item-children .nav-file-title {
+	.nav-files-container .nav-folder.rcs-item-#{$i} .tree-item-children .nav-file-title {
 		color: color-mix(
 				in srgb,
 				var(--rcs-color-#{$i}) var(--rcs-base-color-modifier),


### PR DESCRIPTION
Fixes #19

## What this changes

Switches the three selectors in the `@for` color loop in `styles.scss` from the rigid child chain `.nav-files-container > div > .nav-folder.rcs-item-N` to a descendant selector `.nav-files-container .nav-folder.rcs-item-N`.

## Why

On recent Obsidian versions the plugin stops coloring the sidebar. The JS still works — it locates each folder via `[data-path]` and adds the `rcs-item-N` classes correctly — but **no colors appear** because the CSS no longer matches the DOM.

Obsidian now wraps the file tree in a root node and nests the top-level folders one level deeper:

```
.nav-files-container
  └─ .tree-item.nav-folder.mod-root          ← root wrapper (data-path="/")
       └─ .tree-item-children.nav-folder-children
            └─ .tree-item.nav-folder.rcs-item-1   ← top-level folders (classes are applied here)
```

The old selector assumed the folders were direct grandchildren via a plain `div` (`> div > .nav-folder`), so the chain breaks and the rules never apply.

Using a descendant combinator matches regardless of intermediate wrappers. The class-based conditions (`.nav-folder.rcs-item-N`) are unchanged, and the relative specificity against the `.rcs-item-N.rcs-sub-item ...` rules is preserved (still 4 classes vs 3), so the independent-folder feature behaves exactly as before.

## How I verified

- Diagnosed the live DOM via the developer console on an affected install: `--rcs-color-1` was set and 10 elements carried `rcs-item-*` classes, confirming the breakage was purely the CSS selector, not the JS.
- `npm run build` succeeds; the generated `styles.css` contains 0 occurrences of the old `>div>` chain and 48 of the new descendant selector (16 colors × 3 selectors).
- Confirmed on Obsidian desktop: after the change, top-level folders are colored again.

## Limitations / notes

- Tested on **desktop** only; I was not able to test on mobile, though the change is CSS-only and platform-agnostic.
- `styles.css` is gitignored, so this PR only touches the `styles.scss` source.
